### PR TITLE
1.In the data view of 1.[scan] statistical chart, after clicking refresh, the data view can no longer be opened.

### DIFF
--- a/src/components/stat-char/charts/chart-account.vue
+++ b/src/components/stat-char/charts/chart-account.vue
@@ -139,7 +139,7 @@ export default {
           name: this.$t('statcharts.account.growthYname'),
           nameLocation: 'middle',
           nameTextStyle: {
-
+            padding: [0, 30, 0, 0]
           },
           nameGap: 50,
           type: 'value',

--- a/src/components/stat-char/charts/chart-blockavgtime.vue
+++ b/src/components/stat-char/charts/chart-blockavgtime.vue
@@ -135,7 +135,7 @@ export default {
           name: this.$t('statcharts.block.avgTimeYname'),
           nameLocation: 'middle',
           nameTextStyle: {
-
+            padding: [0, 0, 20, 0]
           },
           nameGap: 50,
           type: 'value',

--- a/src/components/stat-char/charts/chart-blockcount.vue
+++ b/src/components/stat-char/charts/chart-blockcount.vue
@@ -137,7 +137,7 @@ export default {
           name: this.$t('statcharts.block.countYname'),
           nameLocation: 'middle',
           nameTextStyle: {
-
+            padding: [0, 0, 20, 0]
           },
           nameGap: 50,
           type: 'value',

--- a/src/components/stat-char/charts/chart-difficulty.vue
+++ b/src/components/stat-char/charts/chart-difficulty.vue
@@ -135,7 +135,7 @@ export default {
           name: this.$t('statcharts.network.difficultyYname'),
           nameLocation: 'middle',
           nameTextStyle: {
-
+            padding: [0, 0, 20, 0]
           },
           nameGap: 50,
           type: 'value',

--- a/src/components/stat-char/charts/chart-hashrate.vue
+++ b/src/components/stat-char/charts/chart-hashrate.vue
@@ -135,7 +135,7 @@ export default {
           name: this.$t('statcharts.network.hashrateYname'),
           nameLocation: 'middle',
           nameTextStyle: {
-
+            padding: [0, 0, 20, 0]
           },
           nameGap: 50,
           type: 'value',

--- a/src/components/stat-char/charts/chart-miner.vue
+++ b/src/components/stat-char/charts/chart-miner.vue
@@ -78,7 +78,7 @@ export default {
             mark: {show: true},
             dataView: {
               show: true,
-              readOnly: false,
+              readOnly: true,
               title: this.$t('statcharts.charts.dataView'),
               lang: [this.$t('statcharts.charts.dataView'), this.$t('statcharts.charts.close'), this.$t('statcharts.charts.refresh')],
               optionToContent: function (opt) {

--- a/src/components/stat-char/charts/chart-nodes.vue
+++ b/src/components/stat-char/charts/chart-nodes.vue
@@ -65,7 +65,7 @@ export default {
             },
             dataView: {
               show: true,
-              readOnly: false,
+              readOnly: true,
               textareaBorderColor: '#000',
               textColor: '#000',
               buttonColor: '#409EFF',

--- a/src/components/stat-char/charts/chart-txhistory.vue
+++ b/src/components/stat-char/charts/chart-txhistory.vue
@@ -140,7 +140,7 @@ export default {
           name: this.$t('statcharts.transaction.historyTxYname'),
           nameLocation: 'middle',
           nameTextStyle: {
-
+            padding: [0, 0, 20, 0]
           },
           nameGap: 50,
           type: 'value',

--- a/src/components/transaction/detail.vue
+++ b/src/components/transaction/detail.vue
@@ -38,7 +38,8 @@
               </li> -->
               <li>
                 <div class="li-width">{{$t("listHeader.from")}}: </div>
-                <span :class="{'li-content-link': isLink(transactionInfo.from)}" class="list-content-width" @click="toFrom(transactionInfo.from)">{{transactionInfo.from}}</span>
+                <span v-if="transactionInfo.inorout === true" :class="{'table-link-color': isLink(transactionInfo.from)}" class="list-content-width" @click="toFrom(transactionInfo.from)">{{transactionInfo.from}}</span>
+                <span v-else class="list-content-width">{{scope.row.from}}</span>
               </li>
               <li>
                 <div class="li-width">{{$t("listHeader.to")}}: </div>

--- a/src/components/transaction/index.vue
+++ b/src/components/transaction/index.vue
@@ -58,7 +58,8 @@
                 width="310"
                 :label="$t('listHeader.from')">
                 <template slot-scope="scope">
-                  <span :class="{'table-link-color': isLink(scope.row.from)}" class="list-content" @click="toFrom(scope.row.from)">{{scope.row.from}}</span>
+                  <span v-if="scope.row.inorout === true" :class="{'table-link-color': isLink(scope.row.from)}" class="list-content" @click="toTx(scope.row.from)">{{scope.row.from}}</span>
+                  <span v-else class="list-content">{{scope.row.from}}</span>
                 </template>
               </el-table-column>
               <el-table-column


### PR DESCRIPTION
2.[scan] statistical graph Y axis data and string overlap